### PR TITLE
POS-1238: Add Clover Payroll Omniauth Strategy

### DIFF
--- a/lib/omniauth/clover.rb
+++ b/lib/omniauth/clover.rb
@@ -1,2 +1,3 @@
 require "omniauth/clover/version"
 require "omniauth/strategies/clover"
+require "omniauth/strategies/clover_payroll"

--- a/lib/omniauth/clover/version.rb
+++ b/lib/omniauth/clover/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Clover
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end

--- a/lib/omniauth/strategies/clover_payroll.rb
+++ b/lib/omniauth/strategies/clover_payroll.rb
@@ -1,0 +1,100 @@
+require 'omniauth/strategies/oauth2'
+
+module OmniAuth
+  module Strategies
+    class CloverPayroll < OmniAuth::Strategies::OAuth2
+
+      option :name, 'clover_payroll'
+
+      # This is where you pass the options you would pass when
+      # initializing your consumer from the OAuth gem.
+
+      option :client_options, {
+        :site           => 'https://www.clover.com',
+        :authorize_url  => '/oauth/authorize',
+        :token_url      => '/oauth/token'
+      }
+
+      option :authorize_options, [:redirect_uri, :response_type, :state]
+
+
+      # After successful authentication, client information is returned
+      #
+      # Response parameters
+      # -------------------
+      #   merchant_id:  An ID that uniquely identifies the merchant who has authenticated with your app.
+      #
+      #   employee_id:  The employee ID of the current user. You can use this value to identify whether 
+      #                 the current user is the owner of the merchant account, an employee, or someone else.
+      #
+      #   client_id:    The application ID that the user is authenticated to. If your app supports multiple 
+      #                 markets (and you specified the client_ids parameter in the request to /oauth/authorize, 
+      #                 then use this value to determine which of your apps the user authenticated against.
+      #
+      #   code:         Authorization code.
+      #
+      #
+      # Employee Information
+      # --------------------
+      # Retrieves information for single employee
+      #
+      #   id (string, optional):                    Unique identifier
+      #   name (string):                            Full name of the employee
+      #   email (string, optional):                 Email of the employee (optional)
+      #   pin (string, optional):                   Employee PIN (hashed)
+      #   role (string, optional):                  ['ADMIN' or 'MANAGER' or 'EMPLOYEE']: Employee System Role
+      #
+      #   roles (array[Reference], optional)
+      #   customId (string, optional):              Custom ID of the employee
+      #   shifts (array[Reference], optional):      This employee's shifts
+      #   nickname (string, optional):              Nickname of the employee (shows up on receipts)
+      #   unhashedPin (string, optional):           Employee PIN
+      #   payments (array[Reference], optional):    This employee's payments
+      #   inviteSent (boolean, optional):           Returns true if this employee was sent an invite to activate their account
+      #   isOwner (boolean, optional):              Returns true if this employee is the owner account for this merchant
+      #   orders (array[Reference], optional):      This employee's orders
+      #   claimedTime (long, optional):             Timestamp of when this employee claimed their account
+
+      uid { 
+        raw_info['id'] 
+      }
+
+      info do 
+        {
+          :name         => raw_info['name'],
+          :first_name   => first_name,
+          :last_name    => last_name,
+          :email        => raw_info['email'],
+          :role         => raw_info['role'],
+          :urls         => { 'Clover' => raw_info['href'] }
+        }
+      end
+
+      extra do 
+        {
+          :merchant_id  => request.params['merchant_id'],
+          :employee_id  => request.params['employee_id'],
+          :client_id    => request.params['client_id'],
+          :code         => request.params['code']
+        }
+      end
+
+      def raw_info
+        merchant_id   = request.params['merchant_id']
+        empployee_id  = request.params['employee_id']
+        @raw_info ||= access_token.get("/v3/merchants/#{merchant_id}/employees/#{empployee_id}").parsed
+      end
+
+
+      private
+
+      def first_name
+        @raw_info['name'].blank? ? "" : @raw_info['name'].split(' ').first
+      end
+
+      def last_name
+        @raw_info['name'].blank? ? "" : @raw_info['name'].split[1..-1].join(' ')
+      end
+    end
+  end
+end

--- a/spec/omniauth/strategies/clover_payroll_spec.rb
+++ b/spec/omniauth/strategies/clover_payroll_spec.rb
@@ -1,0 +1,100 @@
+require 'spec_helper'
+require 'omniauth-clover'
+
+describe OmniAuth::Strategies::CloverPayroll do
+  let(:request) { double('Request', :params => {}, :cookies => {}, :env => {}) }
+  let(:app) {
+    lambda do
+      [200, {}, ["Hello."]]
+    end
+  }
+
+  subject do
+    OmniAuth::Strategies::CloverPayroll.new(app, 'appid', 'secret', @options || {}).tap do |strategy|
+      allow(strategy).to receive(:request) {
+        request
+      }
+    end
+  end
+
+  before do
+    OmniAuth.config.test_mode = true
+  end
+
+  after do
+    OmniAuth.config.test_mode = false
+  end
+
+  describe '#client_options' do
+    it 'has correct site' do
+      expect(subject.client.site).to eq('https://www.clover.com')
+    end
+
+    it 'has correct authorize_url' do
+      expect(subject.client.options[:authorize_url]).to eq('/oauth/authorize')
+    end
+
+    it 'has correct token_url' do
+      expect(subject.client.options[:token_url]).to eq('/oauth/token')
+    end
+
+    describe "overrides" do
+      it 'should allow overriding the site' do
+        @options = {:client_options => {'site' => 'https://example.com'}}
+        expect(subject.client.site).to eq('https://example.com')
+      end
+
+      it 'should allow overriding the authorize_url' do
+        @options = {:client_options => {'authorize_url' => 'https://example.com'}}
+        expect(subject.client.options[:authorize_url]).to eq('https://example.com')
+      end
+
+      it 'should allow overriding the token_url' do
+        @options = {:client_options => {'token_url' => 'https://example.com'}}
+        expect(subject.client.options[:token_url]).to eq('https://example.com')
+      end
+    end
+  end
+
+  describe "#authorize_options" do
+    [:redirect_uri, :response_type, :state].each do |k|
+      it "should support #{k}" do
+        @options = {k => 'http://someval'}
+        expect(subject.authorize_params[k.to_s]).to eq('http://someval')
+      end
+    end
+
+    describe "redirect_uri" do
+      it 'should default to nil' do
+        @options = {}
+        expect(subject.authorize_params['redirect_uri']).to eq(nil)
+      end
+
+      it 'should set the redirect_uri parameter if present' do
+        @options = {:redirect_uri => 'https://example.com'}
+        expect(subject.authorize_params['redirect_uri']).to eq('https://example.com')
+      end
+    end
+
+    describe 'response_type' do
+      it 'should default to "code"' do
+        @options = {}
+        expect(subject.authorize_params['response_type']).to eq(nil)
+      end
+
+      it 'should set the response_type parameter if present' do
+        @options = {:response_type => 'token'}
+        expect(subject.authorize_params['response_type']).to eq('token')
+      end
+    end
+
+    describe 'state' do
+      it 'should set the state parameter' do
+        @options = {:state => 'some_state'}
+        expect(subject.authorize_params['state']).to eq('some_state')
+        expect(subject.session['omniauth.state']).to eq('some_state')
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
* Clover wants us to use different URLs for using Oauth with Clover Payroll customers.

TODO: Update with URLs